### PR TITLE
fix: support trailing whitespaces in PEM contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -424,10 +424,10 @@ let ecKeyUtils = (() => {
 
                   let s = null;
                   // DER encoding of ECPrivateKey
-                  if (s = /^\-\-\-\-\-BEGIN EC PRIVATE KEY\-\-\-\-\-\n([^]+)\n\-\-\-\-\-END EC PRIVATE KEY\-\-\-\-\-$/g.exec(pemContent))
+                  if (s = /^\-\-\-\-\-BEGIN EC PRIVATE KEY\-\-\-\-\-\n([^]+)\n\-\-\-\-\-END EC PRIVATE KEY\-\-\-\-\-\s*$/g.exec(pemContent))
                         return parseDer$Ecsk(Buffer.from(s[1], 'base64'));
                   // DER encoding of SubjectPublicKeyInfo
-                  else if (s = /^\-\-\-\-\-BEGIN PUBLIC KEY\-\-\-\-\-\n([^]+)\n\-\-\-\-\-END PUBLIC KEY\-\-\-\-\-$/g.exec(pemContent))
+                  else if (s = /^\-\-\-\-\-BEGIN PUBLIC KEY\-\-\-\-\-\n([^]+)\n\-\-\-\-\-END PUBLIC KEY\-\-\-\-\-\s*$/g.exec(pemContent))
                         return parseDer$Spki(Buffer.from(s[1], 'base64'));
                   else
                         throw Error('Invalid or unsupported PEM content');


### PR DESCRIPTION
Adds support for parsing PEM files with trailing whitespaces, meant to support EOF new lines.
This is a common standard and many text editors, IDEs and linters will have default setting to automatically include `\n` or `\r\n` in text files such as .pem.


PS: [notice](https://github.com/tibetty/eckey-utils/pull/2/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R488) how even Github web editor added `\n` to the changed `index.js` file
